### PR TITLE
Slot based bin processing

### DIFF
--- a/main/static/css/rhizo/app.css
+++ b/main/static/css/rhizo/app.css
@@ -55,6 +55,20 @@ div.sequenceUnits {
 	font-size: 12px;
 }
 
+.btn span.glyphicon {    			
+	opacity: 0;				
+}
+.btn.active span.glyphicon {				
+	opacity: 1;				
+}
+
+.dropdown-divider{
+    height:0;
+    margin:.5rem 0;
+    overflow:hidden;
+    border-top:1px solid #e9ecef
+}
+
 div.log {
 	padding: 2px;
 	height: 200px;

--- a/main/static/js/rhizo/blocks.js
+++ b/main/static/js/rhizo/blocks.js
@@ -118,6 +118,64 @@ function createBlock(blockSpec) {
 		// store in collection of blocks
 		g_liveBlocks[name] = block;
 		break;
+
+	// rhizotron bin selecton block
+	case 'rhizo_bin':
+		// Main div
+		blockElem = $('<div>', {class: 'rhizo_binBlock col-md-3', style: 'padding-left: 0px; padding-bottom: 15px;'});
+		blockElem.attr('value', blockSpec.value);
+
+		// The split-button
+		split_button = $('<div>', {class: 'btn-group', style:'margin-bottom: 0px; width: 100%;' });
+		// split-button main button
+		split_left = $('<button>', {class: 'btn btn-primary', type: 'button', title: 'Process all enabled rhizotrons.',
+										onclick: 'processRhizotronBin(this,0)', html: blockSpec.text, style: 'width: calc(100% - 26px);'});
+		// split-button drop-down button
+		split_right = $('<button>', {class: 'btn btn-primary dropdown-toggle', type: 'button', style: 'width:26px;'});
+		split_right.attr('data-toggle', 'dropdown');
+		split_right.attr('aria-expanded', 'false');
+		$('<span>', {class: 'caret'}).appendTo(split_right);
+
+		// split-button drop-down menu
+		split_menu = $('<ul>', {class: 'dropdown-menu', role: 'menu', style: 'right: 0px; left:auto;'});
+		split_menu_item_1 = $('<li>', {html: '<a href="#" onclick="enableAllRhizotrons(this)">Enable All</a>'});
+		split_menu_item_1.appendTo(split_menu);
+		split_menu_item_2 = $('<li>', {html: '<a href="#" onclick="disableAllRhizotrons(this)">Disable All</a>'});
+		split_menu_item_2.appendTo(split_menu);
+		split_menu_divider = $('<li>', {html: '<div class="dropdown-divider"></div>'});
+		split_menu_divider.appendTo(split_menu);
+			
+		// Add left and right parts and the menu
+		split_left.appendTo(split_button);
+		split_right.appendTo(split_button);
+		split_menu.appendTo(split_button);
+
+		// Add split-button
+		split_button.appendTo(blockElem);
+
+		for(row=0; row<6; row++){
+			rhizo_row = $('<div>', {class: 'btn-group', style: 'padding: 0px; width: 100%;'})
+			rhizo_row.attr('data-toggle', 'buttons');
+			for(col=0; col<2; col++){
+				// Create checkbox to track if a slot is active
+				label = $('<label>', {class: 'btn btn-default active', html: 'Slot ' + (2*row+col+1), 
+										title: 'Enable/Disable Slot',
+										style: 'width: 50%', value: 2*row+col});
+				checkbox = $('<input>', {type: 'checkbox', autocomplete: 'off'});
+				checkbox.prop('checked');
+				checkbox.appendTo(label);					
+				label.appendTo(rhizo_row);
+				// Add a 'start on slot' menu item
+				split_menu_start_with = $('<li>', {html: '<a href="#" onclick="processRhizotronBin(this,' +
+											(2*row+col) + ')">Start On Slot ' + (2*row+col+1) + '</a>', 
+											title: 'Process enabled rhizotrons beginning with slot ' + (2*row+col+1) + '.'});
+				split_menu_start_with.appendTo(split_menu); 
+			}
+			rhizo_row.appendTo(blockElem);
+		}
+		
+
+		break;
 	}
 	return blockElem;
 }
@@ -209,4 +267,39 @@ function initImageSequence(block) {
 
 	// make sure we receive updates for this sequence
 	subscribeToFolder(block.folderPath);
+}
+
+
+// ======== rhizotron bin block classes ========
+// Process the bin
+function processRhizotronBin(e, slot) {
+	// Get the block
+	rhizo_bin_block = $(e.closest(".rhizo_binBlock"));
+
+	// Get the bin number
+	rhizo_bin = rhizo_bin_block.attr('value');
+
+	// Get the block's checked checkboxes 
+	checked_labels = rhizo_bin_block.find('label').filter('.active');
+
+	// Determine the value we'll need to send as part of the message
+	enable_mask = 0;
+	
+	// Loop through all the labels
+	checked_labels.each(function(){
+		enable_mask += 2**$(this).attr('value');
+	});
+
+	// Send a message to the client
+	sendMessage("processBin", {binIndex: rhizo_bin, enableMask: enable_mask, startOn: slot});
+}
+
+// Select all rhizotrons in a rhizotron_bin
+function enableAllRhizotrons(e) {
+	$(e.closest(".rhizo_binBlock")).find('label').addClass('active');
+}
+
+// Select no rhizotrons in a rhizotron_bin
+function disableAllRhizotrons(e) {
+	$(e.closest(".rhizo_binBlock")).find('label').removeClass('active');
 }


### PR DESCRIPTION
This update allows starting bin processing on a specified slot and allows slots to be excluded from processing via an enable mask.

Block specs need to add a new section to use the update.
An example of the new block in use:
	{type: 'heading', text: 'Bin Processing Operations'},
	{
		type: 'hgroup',
		blocks: [
		    {type: 'rhizo_bin', value: '0', text: 'Process Bin 1', primary: 1},
		    {type: 'rhizo_bin', value: '1', text: 'Process Bin 2', primary: 1},
		    {type: 'rhizo_bin', value: '2', text: 'Process Bin 3', primary: 1},
		    {type: 'rhizo_bin', value: '3', text: 'Process Bin 4', primary: 1},
		    {type: 'rhizo_bin', value: '4', text: 'Process Bin 5', primary: 1},
		    {type: 'rhizo_bin', value: '5', text: 'Process Bin 6', primary: 1},
		    {type: 'rhizo_bin', value: '6', text: 'Process Bin 7', primary: 1},
		    {type: 'rhizo_bin', value: '7', text: 'Process Bin 8', primary: 1},
		],
	},