### PR TITLE
Upgrade to Python 3.8-compatible Twilio library

### DIFF
--- a/main/messages/outgoing_messages.py
+++ b/main/messages/outgoing_messages.py
@@ -8,7 +8,7 @@ from email.mime.text import MIMEText
 
 # external imports
 try:
-    from twilio.rest import TwilioRestClient
+    from twilio.rest import Client
 except ModuleNotFoundError:
     pass
 from sqlalchemy.orm.exc import NoResultFound
@@ -150,5 +150,5 @@ def send_text_message(phone_numbers, message, server_config):
     account_sid = server_config['TWILIO_ACCOUNT_SID']
     auth_token = server_config['TWILIO_AUTH_TOKEN']
     from_number = server_config['TEXT_FROM_PHONE_NUMBER']
-    client = TwilioRestClient(account_sid, auth_token)
+    client = Client(account_sid, auth_token)
     message = client.messages.create(to = phone_numbers, from_ = from_number, body = message)

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,6 @@ gunicorn  # make this optional
 Markdown
 Pillow
 SQLAlchemy
-twilio==5.6.0  # make this optional
+twilio==6.46.0  # make this optional
 xlrd
 xlwt


### PR DESCRIPTION
Version 5.x of the Twilio client library called `cgi.parse_qs` which was removed
in Python 3.8. Upgrade to a newer version of the library. The new library version
reorganized its class hierarchy, so update the import accordingly.