### PR TITLE
Use boto3 instead of boto

### DIFF
--- a/main/resources/s3_storage_manager.py
+++ b/main/resources/s3_storage_manager.py
@@ -1,13 +1,23 @@
-import boto
+import io
+
+import boto3
+from botocore.errorfactory import ClientError
 
 
 class S3StorageManager():
 
     def __init__(self, app_config):
-        self.connection = boto.connect_s3(app_config['S3_ACCESS_KEY'], app_config['S3_SECRET_KEY'])
+        if 'S3_ACCESS_KEY' in app_config:
+            self.s3 = boto3.resource(
+                's3',
+                aws_access_key_id=app_config['S3_ACCESS_KEY'],
+                aws_secret_access_key=app_config['S3_SECRET_KEY']
+            )
+        else:
+            self.s3 = boto3.resource('s3')
         self.bucket_name = app_config['S3_STORAGE_BUCKET']
         self.write_allowed = app_config['PRODUCTION'] or app_config['S3_STORAGE_BUCKET'].endswith('testing')
-        self.bucket = self.connection.get_bucket(self.bucket_name)  # fix(soon): should we use this in read/write? currently just using it in exists()
+        self.bucket = self.s3.Bucket(self.bucket_name)
         self.verbose = False
 
     # write data to bulk storage
@@ -17,24 +27,29 @@ class S3StorageManager():
             return  # make sure we aren't writing to prod from a test system; should make something more bulletproof than this
         if self.verbose:
             print('writing to bucket: %s, key: %s, data len: %d' % (self.bucket_name, data_path, len(data)))
-        bucket = self.connection.get_bucket(self.bucket_name)
-        key = boto.s3.key.Key(bucket)
-        key.key = data_path
-        key.set_contents_from_string(data)
+        self.bucket.put_object(Body=data, Key=data_path)
 
     # read data from bulk storage
     def read(self, data_path):
-        bucket = self.connection.get_bucket(self.bucket_name)
-        key = bucket.get_key(data_path)
         if self.verbose:
             print('reading from bucket: %s, key: %s' % (self.bucket_name, data_path))
-        return key.get_contents_as_string() if key else None
+        obj = self.bucket.Object(data_path).get()
+        try:
+            return obj['Body'].read()
+        except ClientError as e:
+            if e.response['ResponseMetadata']['HTTPStatusCode'] == 404:
+                return None
+            else:
+                raise e
 
     # returns true if object exists in bulk storage
     # fix(later): remove or improve this
     def exists(self, data_path):
-        key = self.bucket.get_key(data_path)
-        return not key is None
+        response = self.s3.list_objects_v2(Bucket=self.bucket_name, Prefix=data_path)
+        for obj in response.get('Contents', []):
+            if obj['Key'] == data_path:
+                return True
+        return False
 
     # fix(soon): implement and use this
     def delete(self, data_path):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 bcrypt
-boto
+boto3==1.16.11
 Flask
 Flask-Login
 Flask-RESTful


### PR DESCRIPTION
The boto library is no longer maintained and boto3 has better support for picking
up credentials from multiple sources (EC2 instance profile roles, etc.)

The existing credentials mechanism (specifying keys in `config.py`) continues to
work, but if `S3_ACCESS_KEY` isn't defined in the configuration, the code will let
boto3 look for default credentials elsewhere.

Manually tested:

1. Created a new S3 bucket with a name ending in `testing` and set
   `S3_STORAGE_BUCKET` to its name
2. Commented out `S3_ACCESS_KEY` and `S3_SECRET_KEY` and started the server
3. Uploaded a JPEG file to a folder and confirmed that it showed up in the UI and
   that I could download it
4. Listed files in my bucket to confirm the server actually uploaded to it
5. Set `S3_ACCESS_KEY` and `S3_SECRET_KEY` to bogus values and restarted the
   server
6. Tried to download the photo from the UI and confirmed the server got an
   authentication error from boto3 (confirming that the config settings override
   the default authentication source)
