### PR TITLE
Improve Docker-based execution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,28 +1,42 @@
-FROM python:2.7.15
+FROM python:3.8.5-buster AS build
 
 WORKDIR /rhizo-server
 
-# install dependencies
-COPY requirements.txt ./
-RUN pip install -r requirements.txt
+# Install expensive dependencies as a separate build step so we don't have to repeat it if
+# cheaper dependencies are added/removed.
+COPY requirements-prebuild.txt ./
+RUN pip install -r requirements-prebuild.txt
 RUN pip install psycopg2-binary
 
-# uncomment to install flow-server extension dependencies
-#RUN pip install rauth
-#RUN pip install python-jose
-#RUN pip install requests
+# Install remaining dependencies
+COPY requirements.txt ./
+RUN pip install -r requirements.txt
 
-# copy in the app source
-COPY . .
+# uncomment to install flow-server extension dependencies
+#RUN pip install rauth python-jose requests
+
+COPY sample_settings sample_settings
+COPY prep_config.py ./
 
 # add the config
-RUN python prep_config.py
-RUN echo "DISCLAIMER = 'This is pre-release code; the API and database structure will probably change.'" >> settings/config.py
+RUN python prep_config.py \
+    && echo "DISCLAIMER = 'This is pre-release code; the API and database structure will probably change.'" >> settings/config.py
+
+FROM python:3.8.5-buster
+
+WORKDIR /rhizo-server
+
+COPY --from=build /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
+
+# copy in the app source
+COPY run.py run_worker.py ./
+COPY main main
+COPY --from=build /rhizo-server/settings settings
 
 # create an empty extensions folder
-RUN mkdir extensions
-RUN touch extensions/__init__.py
+RUN mkdir extensions && touch extensions/__init__.py
+
+EXPOSE 5000
 
 # run the server in unbuffered output mode
-EXPOSE 80
 CMD [ "python", "-u", "run.py", "-s" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,33 @@
 # NOTE: this is only meant to be used in development, not production
 
-version: '3'
+version: '2'
 services:
   app:
     build:
       context: .
-      dockerfile: Dockerfile
     # run python unbuffered so debug print commands are visible immediately in docker log
-    command: python -u run.py -s
+    command: python -u run.py -s -l 0.0.0.0
     ports:
-      - 80:5000
+      - 5000:5000
+    depends_on:
+      - postgres
     environment:
       SQLALCHEMY_DATABASE_URI: postgres://rhizo:rhizo@postgres
       AUTOLOAD_EXTENSIONS: 'true'
+    #
+    # If you want to use the local settings/config.py in the container, you
+    # could bind-mount it
+    #
+    # volumes:
+    #   - ./settings:/rhizo-server/settings
+    #
     # example of linking to an extension that is in a sibling folder
-    #volumes:
-    #  - ../flow-server:/rhizo-server/extensions/flow-server
-    depends_on:
-      - postgres
+    #
+    # volumes:
+    #   - ../flow-server:/rhizo-server/extensions/flow-server
+
   postgres:
-    image: postgres:9.3
+    image: postgres:13
     environment:
       POSTGRES_PASSWORD: rhizo
       POSTGRES_USER:     rhizo

--- a/requirements-prebuild.txt
+++ b/requirements-prebuild.txt
@@ -1,0 +1,6 @@
+# This file should have requirements that are especially expensive to build. They will be
+# installed in a separate step in the Docker build so that they're cached as a separate
+# layer. That way when we add ordinary plain-Python packages to requirements.txt, it won't
+# force a time-consuming rebuild of the expensive stuff.
+
+gevent==20.9.0


### PR DESCRIPTION
Update the Docker configuration to more closely resemble what we'll need to deploy
the server using Balena. Most of this is in the Docker config:

* Use Python 3.8.5 on Debian buster
* Use PostgreSQL 13 (no reason not to use a recent version)
* Use a multistage build so the final container doesn't need to include build
  tools if dependencies require compilation; this is kind of a no-op for the
  generic Dockerfile but will be significant for Balena
* Be selective about what gets copied into the image
* Reduce the `docker-compose.yml` version number to 2 for Balena compatibility
  (the file doesn't use any version 3 features)

In addition, tweak the server code to be a bit more Docker-friendly:

* Allow the listen address and port number to be specified on the command line
  since you can't expose localhost-only listen ports on Docker for Mac
* When running in WebSockets mode, gracefully shut down on SIGTERM so the
  container stops right away when you run `docker-compose down`
