### PR TITLE
Add support for Balena builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ settings
 extensions
 main/rhizo.db
 main/static/css/system.css
+Dockerfile.template

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,7 @@
+# Install dependencies using a separate container. For regular Docker builds, this doesn't
+# really make much difference, but for Balena builds, our Makefile replaces the  base image
+# with one that includes compilers and header files that aren't included in the minimal
+# Python image that gets deployed to devices.
 FROM python:3.8.5-buster AS build
 
 WORKDIR /rhizo-server
@@ -22,6 +26,8 @@ COPY prep_config.py ./
 RUN python prep_config.py \
     && echo "DISCLAIMER = 'This is pre-release code; the API and database structure will probably change.'" >> settings/config.py
 
+# For Balena, our Makefile replaces this with a Balena base image that does not include
+# build tools such as compilers.
 FROM python:3.8.5-buster
 
 WORKDIR /rhizo-server

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,11 @@
+#
+# Generate a Balena-friendly Dockerfile from the default one. This just replaces the
+# base image names with Balena's per-architecture ones.
+#
+Dockerfile.template: Dockerfile
+	sed -e 's@^FROM python:\([0-9.]*\)-\([^ ]\)@FROM balenalib/%%BALENA_MACHINE_NAME%%-debian-python:\1-\2@' \
+		-e 's@^FROM \(.*\) AS build$$@FROM \1-build AS build@' \
+		< $< > $@
+
+raspi-build: Dockerfile.template
+	balena build -A aarch64 -d raspberrypi4-64


### PR DESCRIPTION
Generate a Balena-compatible Dockerfile template from the regular Dockerfile.
For convenience, add a Makefile target that builds for the Raspberry Pi 4
locally; this is mostly just to test the Dockerfile itself, since `balena push`
will implicitly build the code.
