### PR TITLE
PEP8 E221: Single space before operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ You can customize the server behavior with settings and extensions. We use the f
 Coding style guidelines:
 
 *   Python code should be mostly PEP8 compliant. We currently ignore some PEP8 errors:
-    E124, E221, E266, E402, E501, E712, E713
+    E501, E712, E713
 *   Aim to use single quotes around strings.
 *   Template variables should have spaces just inside brackes: `{{ template_var }}`
 *   Use underscores for database fields, API parameters, message types, and message parameters.

--- a/main/messages/models.py
+++ b/main/messages/models.py
@@ -4,36 +4,36 @@ from main.app import db
 # The Message model holds messages temporarily in the database.
 # (It is used by the MessageQueueBasic class; other message queue implementations may use other message storages.)
 class Message(db.Model):
-    __tablename__   = 'messages'
-    id                      = db.Column(db.BigInteger().with_variant(db.Integer, "sqlite"), primary_key=True)
-    timestamp               = db.Column(db.DateTime, nullable=False)
-    sender_controller_id    = db.Column(db.ForeignKey('resources.id'))  # nullable (null if sent by user or server system)
-    sender_user_id          = db.Column(db.ForeignKey('users.id'))      # nullable (null if sent by controller or server system)
-    folder_id               = db.Column(db.ForeignKey('resources.id'), nullable=False)  # not nullable; all messages must belong to a folder
-    type                    = db.Column(db.String(40), nullable=False)
-    parameters              = db.Column(db.String, nullable=False)    # JSON dictionary
-    attributes              = db.Column(db.String)                      # JSON field containing extra message attributes
+    __tablename__ = 'messages'
+    id = db.Column(db.BigInteger().with_variant(db.Integer, "sqlite"), primary_key=True)
+    timestamp = db.Column(db.DateTime, nullable=False)
+    sender_controller_id = db.Column(db.ForeignKey('resources.id'), comment='nullable (null if sent by user or server system)')
+    sender_user_id = db.Column(db.ForeignKey('users.id'), comment='nullable (null if sent by controller or server system)')
+    folder_id = db.Column(db.ForeignKey('resources.id'), nullable=False, comment='not nullable; all messages must belong to a folder')
+    type = db.Column(db.String(40), nullable=False)
+    parameters = db.Column(db.String, nullable=False, comment='JSON dictionary')
+    attributes = db.Column(db.String, comment='JSON field containing extra message attributes')
     def __repr__(self):
         return '%d: %s, %s' % (self.id, self.timestamp, self.type)
 
 
 # The ActionThrottle model is used to rate-limit certain client-requested activities like sending emails/texts.
 class ActionThrottle(db.Model):
-    __tablename__       = 'action_throttles'
-    id                  = db.Column(db.Integer, primary_key=True)
-    controller_id       = db.Column(db.ForeignKey('resources.id'))      # the controller being throttled (null if user)
-    user_id             = db.Column(db.ForeignKey('users.id'))          # the user being throttled (null if controller)
-    type                = db.Column(db.String(50), nullable=False)    # type of action being throttled
-    recent_usage        = db.Column(db.String, nullable=False)        # list of timestamp numbers
+    __tablename__ = 'action_throttles'
+    id = db.Column(db.Integer, primary_key=True)
+    controller_id = db.Column(db.ForeignKey('resources.id'), comment='the controller being throttled (null if user)')
+    user_id = db.Column(db.ForeignKey('users.id'), comment='the user being throttled (null if controller)')
+    type = db.Column(db.String(50), nullable=False, comment='type of action being throttled')
+    recent_usage = db.Column(db.String, nullable=False, comment='list of timestamp numbers')
 
 
 # The OutgoingMessage model holds email/text messages being sent by the system.
 class OutgoingMessage(db.Model):
-    __tablename__       = 'outgoing_messages'
-    id                  = db.Column(db.Integer, primary_key=True)
-    controller_id       = db.Column(db.ForeignKey('resources.id'))  # the originating controller (null if user)
-    user_id             = db.Column(db.ForeignKey('users.id'))      # the originating user (null if controller)
-    timestamp           = db.Column(db.DateTime, nullable=False)
-    recipients          = db.Column(db.String, nullable=False)    # e.g. email addresses or phone numbers
-    message             = db.Column(db.String, nullable=False)    # e.g. message content or subject
-    attributes          = db.Column(db.String, nullable=False)    # JSON field containing extra message attributes
+    __tablename__ = 'outgoing_messages'
+    id = db.Column(db.Integer, primary_key=True)
+    controller_id = db.Column(db.ForeignKey('resources.id'), comment='the originating controller (null if user)')
+    user_id = db.Column(db.ForeignKey('users.id'), comment='the originating user (null if controller)')
+    timestamp = db.Column(db.DateTime, nullable=False)
+    recipients = db.Column(db.String, nullable=False, comment='e.g. email addresses or phone numbers')
+    message = db.Column(db.String, nullable=False, comment='e.g. message content or subject')
+    attributes = db.Column(db.String, nullable=False, comment='JSON field containing extra message attributes')

--- a/main/resources/models.py
+++ b/main/resources/models.py
@@ -5,26 +5,26 @@ from main.app import db
 # The Resource model provides a hierarchy of folders and files.
 # It is the primary table for organization data stored on the server.
 class Resource(db.Model):
-    __tablename__       = 'resources'
-    id                  = db.Column(db.Integer, primary_key=True)
-    last_revision_id    = db.Column(db.Integer)                     # can be null for folder resources or empty files/sequences
-    organization_id     = db.Column(db.ForeignKey('resources.id'))  # would like this to be non-null, but how else do we create first organization?
-    creation_timestamp  = db.Column(db.DateTime)
-    modification_timestamp = db.Column(db.DateTime)                 # fix(later): remove this and use revision timestamp? what about folders? should we track modification timestamps for this?
+    __tablename__ = 'resources'
+    id = db.Column(db.Integer, primary_key=True)
+    last_revision_id = db.Column(db.Integer, comment='can be null for folder resources or empty files/sequences')
+    organization_id = db.Column(db.ForeignKey('resources.id'))  # would like this to be non-null, but how else do we create first organization?
+    creation_timestamp = db.Column(db.DateTime)
+    modification_timestamp = db.Column(db.DateTime)  # fix(later): remove this and use revision timestamp? what about folders? should we track modification timestamps for this?
 
     # meta-data that could eventually have change tracking (probably best to move into a separate table e.g. resource_meta_revisions)
-    parent_id           = db.Column(db.ForeignKey('resources.id'), index=True)
-    parent              = db.relationship('Resource', remote_side=[id], foreign_keys=[parent_id])
-    name                = db.Column(db.String, nullable=False)
-    type                = db.Column(db.Integer, nullable=False)                 # fix(later): add index for this?
-    permissions         = db.Column(db.String)                                    # JSON; NULL -> inherit from parent
-    system_attributes   = db.Column(db.String, nullable=False, default='{}')  # JSON dictionary; additional attributes of the resource (system-defined)
-    user_attributes     = db.Column(db.String)                                    # JSON dictionary; additional attributes of the resource (user-defined)
-    deleted             = db.Column(db.Boolean, nullable=False, default=False)
+    parent_id = db.Column(db.ForeignKey('resources.id'), index=True)
+    parent = db.relationship('Resource', remote_side=[id], foreign_keys=[parent_id])
+    name = db.Column(db.String, nullable=False)
+    type = db.Column(db.Integer, nullable=False)  # fix(later): add index for this?
+    permissions = db.Column(db.String, comment='JSON; NULL -> inherit from parent')
+    system_attributes = db.Column(db.String, nullable=False, default='{}', comment='JSON dictionary; additional attributes of the resource (system-defined)')
+    user_attributes = db.Column(db.String, comment='JSON dictionary; additional attributes of the resource (user-defined)')
+    deleted = db.Column(db.Boolean, nullable=False, default=False)
 
     # fix(soon): remove after migrate
-    hash                = db.Column(db.String(50))
-    size                = db.Column(db.BigInteger)
+    hash = db.Column(db.String(50))
+    size = db.Column(db.BigInteger)
 
     # resource types
     BASIC_FOLDER = 10
@@ -136,20 +136,20 @@ class Resource(db.Model):
 
 # The ResourceRevision model holds a revision history or time series history of a resource.
 class ResourceRevision(db.Model):
-    __tablename__       = 'resource_revisions'
-    id                  = db.Column(db.Integer, primary_key=True)  # upgrade to 64-bit at some point?
-    resource_id         = db.Column(db.ForeignKey('resources.id'), nullable=False, index=True)
-    timestamp           = db.Column(db.DateTime, nullable=False, index=True)
-    data                = db.Column(db.LargeBinary, nullable=True)
+    __tablename__ = 'resource_revisions'
+    id = db.Column(db.Integer, primary_key=True)  # upgrade to 64-bit at some point?
+    resource_id = db.Column(db.ForeignKey('resources.id'), nullable=False, index=True)
+    timestamp = db.Column(db.DateTime, nullable=False, index=True)
+    data = db.Column(db.LargeBinary, nullable=True)
 
 
 # The ResourceView model holds per-used preferences for viewing a resource (e.g. folder sorting).
 class ResourceView(db.Model):
-    __tablename__       = 'resource_views'
-    id                  = db.Column(db.Integer, primary_key=True)
-    resource_id         = db.Column(db.ForeignKey('resources.id'), nullable=False, index=True)
-    user_id             = db.Column(db.ForeignKey('users.id'), nullable=False, index=True)
-    view                = db.Column(db.String, nullable=False)  # JSON string
+    __tablename__ = 'resource_views'
+    id = db.Column(db.Integer, primary_key=True)
+    resource_id = db.Column(db.ForeignKey('resources.id'), nullable=False, index=True)
+    user_id = db.Column(db.ForeignKey('users.id'), nullable=False, index=True)
+    view = db.Column(db.String, nullable=False, comment='JSON string')
 
 
 # ======== other resource-related tables ========
@@ -158,40 +158,40 @@ class ResourceView(db.Model):
 # The Pin model is used for provisioning new controllers. The controller requests a PIN, displays it,
 # and the user enters it. This associates the controller hardware with a controller resource on the server.
 class Pin(db.Model):
-    __tablename__       = 'pins'
-    id                  = db.Column(db.Integer, primary_key=True)
-    pin                 = db.Column(db.Integer, nullable=False)
-    code                = db.Column(db.String(80), nullable=False)  # a key used to make sure only the original controller can check this PIN
-    creation_timestamp  = db.Column(db.DateTime, nullable=False)
-    enter_timestamp     = db.Column(db.DateTime)
-    user_id             = db.Column(db.ForeignKey('users.id'))        # null if not yet entered
-    controller_id       = db.Column(db.ForeignKey('resources.id'))    # null if not yet entered
-    key_created         = db.Column(db.Boolean)
-    attributes          = db.Column(db.String, nullable=False)      # JSON field containing extra attributes
+    __tablename__ = 'pins'
+    id = db.Column(db.Integer, primary_key=True)
+    pin = db.Column(db.Integer, nullable=False)
+    code = db.Column(db.String(80), nullable=False, comment='a key used to make sure only the original controller can check this PIN')
+    creation_timestamp = db.Column(db.DateTime, nullable=False)
+    enter_timestamp = db.Column(db.DateTime)
+    user_id = db.Column(db.ForeignKey('users.id'), comment='null if not yet entered')
+    controller_id = db.Column(db.ForeignKey('resources.id'), comment='null if not yet entered')
+    key_created = db.Column(db.Boolean)
+    attributes = db.Column(db.String, nullable=False, comment='JSON field containing extra attributes')
 
 
 # The Usage model stores data and message usage by organization
 class Usage(db.Model):
-    __tablename__       = 'usage'
-    id                  = db.Column(db.Integer, primary_key=True)
-    organization_id     = db.Column(db.ForeignKey('resources.id'), nullable=False)
-    period              = db.Column(db.String(10), nullable=False)
-    message_count       = db.Column(db.BigInteger, nullable=False)
-    data_bytes          = db.Column(db.BigInteger, nullable=False)
-    attributes          = db.Column(db.String, nullable=False)      # JSON field containing extra attributes
+    __tablename__ = 'usage'
+    id = db.Column(db.Integer, primary_key=True)
+    organization_id = db.Column(db.ForeignKey('resources.id'), nullable=False)
+    period = db.Column(db.String(10), nullable=False)
+    message_count = db.Column(db.BigInteger, nullable=False)
+    data_bytes = db.Column(db.BigInteger, nullable=False)
+    attributes = db.Column(db.String, nullable=False, comment='JSON field containing extra attributes')
 
 
 # The ControllerStatus model stores real-time status information about a controller
 # (external hardware that sends messages using to the server).
 class ControllerStatus(db.Model):
-    __tablename__               = 'controller_status'
-    id                          = db.Column(db.ForeignKey('resources.id'), primary_key=True)
-    client_version              = db.Column(db.String(80), nullable=False)
-    web_socket_connected        = db.Column(db.Boolean, nullable=False)  # not used currently (may be too brittle); remove?
-    last_connect_timestamp      = db.Column(db.DateTime)                   # last time the controler connected
-    last_watchdog_timestamp     = db.Column(db.DateTime)                   # last time the controller sent good watchdog message
-    watchdog_notification_sent  = db.Column(db.Boolean, nullable=False)
-    attributes                  = db.Column(db.String, nullable=False)   # JSON field containing extra controller status information
+    __tablename__ = 'controller_status'
+    id = db.Column(db.ForeignKey('resources.id'), primary_key=True)
+    client_version = db.Column(db.String(80), nullable=False)
+    web_socket_connected = db.Column(db.Boolean, nullable=False)  # not used currently (may be too brittle); remove?
+    last_connect_timestamp = db.Column(db.DateTime, comment='last time the controler connected')
+    last_watchdog_timestamp = db.Column(db.DateTime, comment='last time the controller sent good watchdog message')
+    watchdog_notification_sent = db.Column(db.Boolean, nullable=False)
+    attributes = db.Column(db.String, nullable=False, comment='JSON field containing extra controller status information')
 
     def as_dict(self, extended=False):
         d = {
@@ -207,13 +207,13 @@ class ControllerStatus(db.Model):
 
 # the Thumbnail model stores versions of image resources at multiple scales
 class Thumbnail(db.Model):
-    __tablename__       = 'thumbnails'
-    id                  = db.Column(db.Integer, primary_key=True)
-    resource_id         = db.Column(db.ForeignKey('resources.id'), nullable=False, index=True)
-    width               = db.Column(db.Integer, nullable=False)
-    height              = db.Column(db.Integer, nullable=False)
-    format              = db.Column(db.String(4), nullable=False)
-    data                = db.Column(db.LargeBinary, nullable=False)
+    __tablename__ = 'thumbnails'
+    id = db.Column(db.Integer, primary_key=True)
+    resource_id = db.Column(db.ForeignKey('resources.id'), nullable=False, index=True)
+    width = db.Column(db.Integer, nullable=False)
+    height = db.Column(db.Integer, nullable=False)
+    format = db.Column(db.String(4), nullable=False)
+    data = db.Column(db.LargeBinary, nullable=False)
 
 
 # unit (for use in sequence attributes)

--- a/main/users/models.py
+++ b/main/users/models.py
@@ -4,17 +4,17 @@ from flask_login import UserMixin
 
 # The User model stores information about a human user. A user is identified by a user name or email address.
 class User(UserMixin, db.Model):
-    __tablename__       = 'users'
-    id                  = db.Column(db.Integer, primary_key=True)
-    user_name           = db.Column(db.String(50), nullable=True)  # optional
-    email_address       = db.Column(db.String(100), nullable=False, unique=True)
-    password_hash       = db.Column(db.String(128), nullable=False)
-    full_name           = db.Column(db.String(100), nullable=False)
-    info_status         = db.Column(db.String, nullable=False)  # JSON string indicating which info messages have been displayed to user
-    attributes          = db.Column(db.String, nullable=False)  # JSON string of additional information about user
-    deleted             = db.Column(db.Boolean, nullable=False)
-    creation_timestamp  = db.Column(db.DateTime, nullable=False)
-    role                = db.Column(db.Integer, nullable=False)
+    __tablename__ = 'users'
+    id = db.Column(db.Integer, primary_key=True)
+    user_name = db.Column(db.String(50), nullable=True, comment='optional')
+    email_address = db.Column(db.String(100), nullable=False, unique=True)
+    password_hash = db.Column(db.String(128), nullable=False)
+    full_name = db.Column(db.String(100), nullable=False)
+    info_status = db.Column(db.String, nullable=False, comment='JSON string indicating which info messages have been displayed to user')
+    attributes = db.Column(db.String, nullable=False, comment='JSON string of additional information about user')
+    deleted = db.Column(db.Boolean, nullable=False)
+    creation_timestamp = db.Column(db.DateTime, nullable=False)
+    role = db.Column(db.Integer, nullable=False)
 
     def __repr__(self):
         return '%d: %s' % (self.id, self.email_address)
@@ -37,21 +37,21 @@ class User(UserMixin, db.Model):
 
 # The Key model holds access keys (used for programmatic API access to the server).
 class Key(db.Model):
-    __tablename__           = 'keys'
-    id                      = db.Column(db.Integer, primary_key=True)
-    organization_id         = db.Column(db.ForeignKey('resources.id'), nullable=False)
-    creation_user_id        = db.Column(db.ForeignKey('users.id'), nullable=False)
-    revocation_user_id      = db.Column(db.ForeignKey('users.id'))         # null if not revoked
-    creation_timestamp      = db.Column(db.DateTime, nullable=False)
-    revocation_timestamp    = db.Column(db.DateTime)                       # null if not revoked
-    access_as_user_id       = db.Column(db.ForeignKey('users.id'))         # null if access as controller
-    access_as_controller_id = db.Column(db.ForeignKey('resources.id'))     # null if access as user
-    key_part                = db.Column(db.String(8), nullable=False)
-    key_hash                = db.Column(db.String(128), nullable=False)  # like a password hash, but for a key
+    __tablename__ = 'keys'
+    id = db.Column(db.Integer, primary_key=True)
+    organization_id = db.Column(db.ForeignKey('resources.id'), nullable=False)
+    creation_user_id = db.Column(db.ForeignKey('users.id'), nullable=False)
+    revocation_user_id = db.Column(db.ForeignKey('users.id'), comment='null if not revoked')
+    creation_timestamp = db.Column(db.DateTime, nullable=False)
+    revocation_timestamp = db.Column(db.DateTime, comment='null if not revoked')
+    access_as_user_id = db.Column(db.ForeignKey('users.id'), comment='null if access as controller')
+    access_as_controller_id = db.Column(db.ForeignKey('resources.id'), comment='null if access as user')
+    key_part = db.Column(db.String(8), nullable=False)
+    key_hash = db.Column(db.String(128), nullable=False, comment='like a password hash, but for a key')
 
     # fix(soon): remove these and just use key_hash
-    key_storage             = db.Column(db.String(), nullable=True)
-    key_storage_nonce       = db.Column(db.String(), nullable=True)
+    key_storage = db.Column(db.String(), nullable=True)
+    key_storage_nonce = db.Column(db.String(), nullable=True)
 
     def as_dict(self):
         return {
@@ -68,31 +68,31 @@ class Key(db.Model):
 # The AccountRequest model holds requests for new users and new organizations.
 # Account request may require approval before they are turned into accounts.
 class AccountRequest(db.Model):
-    __tablename__       = 'account_requests'
-    id                  = db.Column(db.Integer, primary_key=True)
-    organization_name   = db.Column(db.String(100))                   # used for new organization
-    organization_id     = db.Column(db.ForeignKey('resources.id'))    # used to join existing organization
-    organization        = db.relationship('Resource')                 # used to join existing organization
-    inviter_id          = db.Column(db.ForeignKey('users.id'))        # used to join existing organization
-    creation_timestamp  = db.Column(db.DateTime, nullable=False)
-    redeemed_timestamp  = db.Column(db.DateTime)
-    access_code         = db.Column(db.String(40), nullable=False)
-    email_address       = db.Column(db.String, nullable=False)
-    email_sent          = db.Column(db.Boolean, nullable=False)     # True if sent successfully
-    email_failed        = db.Column(db.Boolean, nullable=False)     # True if given up on sending
-    attributes          = db.Column(db.String, nullable=False)      # JSON field containing extra attributes
+    __tablename__ = 'account_requests'
+    id = db.Column(db.Integer, primary_key=True)
+    organization_name = db.Column(db.String(100), comment='used for new organization')
+    organization_id = db.Column(db.ForeignKey('resources.id'), comment='used to join existing organization')
+    organization = db.relationship('Resource')  # used to join existing organization
+    inviter_id = db.Column(db.ForeignKey('users.id'), comment='used to join existing organization')
+    creation_timestamp = db.Column(db.DateTime, nullable=False)
+    redeemed_timestamp = db.Column(db.DateTime)
+    access_code = db.Column(db.String(40), nullable=False)
+    email_address = db.Column(db.String, nullable=False)
+    email_sent = db.Column(db.Boolean, nullable=False, comment='True if sent successfully')
+    email_failed = db.Column(db.Boolean, nullable=False, comment='True if given up on sending')
+    attributes = db.Column(db.String, nullable=False, comment='JSON field containing extra attributes')
 
 
 # The OrganizationUser model represents membership of users in organizations.
 # A single user can belong to multiple organizations. A user can be an adminstrator for an organization.
 class OrganizationUser(db.Model):
-    __tablename__   = 'organization_users'
-    id              = db.Column(db.Integer, primary_key=True)
+    __tablename__ = 'organization_users'
+    id = db.Column(db.Integer, primary_key=True)
     organization_id = db.Column(db.ForeignKey('resources.id'), nullable=False)
-    organization    = db.relationship('Resource')
-    user_id         = db.Column(db.ForeignKey('users.id'), nullable=False)
-    user            = db.relationship('User')
-    is_admin        = db.Column(db.Boolean, default=False, nullable=False)
+    organization = db.relationship('Resource')
+    user_id = db.Column(db.ForeignKey('users.id'), nullable=False)
+    user = db.relationship('User')
+    is_admin = db.Column(db.Boolean, default=False, nullable=False)
 
     def as_dict(self):
         return {


### PR DESCRIPTION
This PEP8 rule was only violated by the model definitions. Since removing the
alignment of the equals signs messed up the alignment of the comments, I also
moved most of the comments to the actual column definitions; SQLAlchemy will
include them as column comments on PostgreSQL when it creates tables on a fresh
database.

There were a few PEP8 rules listed as exceptions in the README file that the
code wasn't actually violating, so I removed those too.
