### PR TITLE
PEP8 E265: Comments should have a space after the #

### DIFF
--- a/main/api/resources.py
+++ b/main/api/resources.py
@@ -128,7 +128,7 @@ class ResourceRecord(ApiResource):
 
                     # return data
                     if download:
-                        #timezone = r.root().system_attributes['timezone']  # fix(soon): use this instead of UTC
+                        # timezone = r.root().system_attributes['timezone']  # fix(soon): use this instead of UTC
                         lines = ['utc_timestamp,value\n']
                         for rr in resource_revisions:
                             lines.append('%s,%s\n' % (rr.timestamp.strftime('%Y-%m-%d %H:%M:%S.%f'), rr.data))
@@ -532,7 +532,7 @@ class ResourceList(ApiResource):
             # check for drift
             delta = datetime.datetime.utcnow() - timestamp
             drift = delta.total_seconds()
-            #print 'drift', drift
+            # print 'drift', drift
             if abs(drift) > 30:
 
                 # get current controller correction
@@ -541,7 +541,7 @@ class ResourceList(ApiResource):
                 start_key_time = time.time()
                 key = find_key_fast(auth.password)  # key is provided as HTTP basic auth password
                 end_key_time = time.time()
-                #print '---- key: %.2f' % (end_key_time - start_key_time)
+                # print '---- key: %.2f' % (end_key_time - start_key_time)
                 if key and key.access_as_controller_id:
                     controller_id = key.access_as_controller_id
                     controller_status = ControllerStatus.query.filter(ControllerStatus.id == controller_id).one()
@@ -554,10 +554,10 @@ class ResourceList(ApiResource):
                         attributes['timestamp_correction'] = drift
                         controller_status.attributes = json.dumps(attributes)
                         db.session.commit()
-                        #print 'storing new correction (%.2f)' % correction
+                        # print 'storing new correction (%.2f)' % correction
                     else:
                         pass
-                        #print 'applying previous correction (%.2f)' % correction
+                        # print 'applying previous correction (%.2f)' % correction
                     timestamp += datetime.timedelta(seconds=correction)
         else:
             timestamp = datetime.datetime.utcnow()
@@ -583,8 +583,8 @@ class ResourceList(ApiResource):
                     except NoResultFound:
                         pass
             db.session.commit()
-            #end_time = time.time()
-            #print '==== %.2f' % (end_time - start_time)
+            # end_time = time.time()
+            # print '==== %.2f' % (end_time - start_time)
 
 
 # update resource record system attributes using a dictionary of new system attributes (send via REST API)

--- a/main/app.py
+++ b/main/app.py
@@ -83,7 +83,7 @@ socket_sender.start()
 
 # clear existing websocket connections in database
 # fix(later): revisit this
-#clear_web_sockets()
+# clear_web_sockets()
 
 # load server extensions
 extensions = []

--- a/main/resources/file_conversion.py
+++ b/main/resources/file_conversion.py
@@ -113,8 +113,8 @@ def test():
     print(csv_gen_data)
     print(str(csv_gen_data).strip() == str(csv_data).strip())  # fix(later): probably doens't match due to newlines
 
-    #csvData = convert_xls_to_csv(open('test.xlsx', 'rb').read())
-    #print(csvData)
+    # csvData = convert_xls_to_csv(open('test.xlsx', 'rb').read())
+    # print(csvData)
 
 
 if __name__ == '__main__':

--- a/main/workers/message_monitor.py
+++ b/main/workers/message_monitor.py
@@ -39,7 +39,7 @@ def message_monitor():
 
     # run this on message
     def on_message(client, userdata, msg):
-        #print('MQTT: %s %s' % (msg.topic, msg.payload.decode()))
+        # print('MQTT: %s %s' % (msg.topic, msg.payload.decode()))
         message_struct = json.loads(msg.payload.decode())
         message_type = message_struct['type']
         if message_type == 'update_sequence':


### PR DESCRIPTION
None of these were "comments" per se, just commented-out code, but easy enough to fix them to be PEP8-compliant.
