### PR TITLE
Fix Flake8 issues; add to CI suite

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,9 +35,9 @@ jobs:
         pip install -r tests/requirements.txt
         pip install -r tests/requirements-postgres.txt
 
-    - name: Check PEP8 compliance (pycodestyle)
+    - name: Check code style (flake8)
       run: |
-        .venv/bin/pycodestyle --max-line-length=150 main tests
+        .venv/bin/flake8 --max-line-length=150 main tests
 
     - name: Prep config
       run: |

--- a/main/api/keys.py
+++ b/main/api/keys.py
@@ -104,10 +104,11 @@ class KeyList(ApiResource):
                 if key.access_as_user_id:
                     creation_user_id = key.access_as_user_id
                 else:
+                    creation_user_id = None
                     abort(403)
             else:
                 creation_user_id = current_user.id
-            (k, key_text) = create_key(current_user.id, organization_id, None, access_as_controller_id, key_text=request.values.get('key'))
+            (k, key_text) = create_key(creation_user_id, organization_id, None, access_as_controller_id, key_text=request.values.get('key'))
             return {'status': 'ok', 'id': k.id, 'secret_key': key_text}
 
         # create a key for a users
@@ -115,7 +116,7 @@ class KeyList(ApiResource):
         elif 'access_as_user_id' in request.values:
             access_as_user_id = request.values['access_as_user_id']
             try:
-                u = User.query.filter(User.id == access_as_user_id, not_(User.deleted)).one()
+                User.query.filter(User.id == access_as_user_id, not_(User.deleted)).one()
             except NoResultFound:
                 abort(400)
             organization_id = request.values['organization_id']

--- a/main/api/views.py
+++ b/main/api/views.py
@@ -1,24 +1,18 @@
 # standard python imports
-import json
-import base64
 import random
 import logging
-import datetime
 
 
 # external imports
-import gevent  # fix(clean): remove?
 from flask import request, abort, session
 from flask_login import current_user
 
 
 # internal imports from outside API directory
-from main.app import db, app, api_
-from main.util import ssl_required
+from main.app import app, api_
 from main.users.permissions import generate_access_code
 from main.users.auth import message_auth_token
 from main.messages.socket_receiver import manage_web_socket
-from main.resources.models import Resource
 
 
 # internal local (API) imports

--- a/main/app.py
+++ b/main/app.py
@@ -1,13 +1,12 @@
 import os
 import pathlib
-import random
 import importlib
 from flask import Flask, render_template, redirect, request
 from flask_sqlalchemy import SQLAlchemy
 from flask_login import LoginManager
 from flask_restful import Api
 from . import config
-from .messages.socket_sender import SocketSender, clear_web_sockets
+from .messages.socket_sender import SocketSender
 from .messages.message_queue_basic import MessageQueueBasic
 from .messages.message_sender import MessageSender
 

--- a/main/app_run.py
+++ b/main/app_run.py
@@ -1,17 +1,23 @@
-# this file can be used to provide an app object to gunicorn;
-# it includes the app object from the app module and makes sure all views/models are imported;
-# it provides an alternative to putting everything inside an __init__.py file;
-# it isn't used by the top-level run.py program
-from main.app import *
-
+"""
+this file can be used to provide an app object to gunicorn;
+it includes the app object from the app module and makes sure all views/models are imported;
+it provides an alternative to putting everything inside an __init__.py file;
+it isn't used by the top-level run.py program
+"""
+from main.app import app
 
 # import all views
-from main.users import views
-from main.api import views
-from main.resources import views  # this should be last because it includes the catch-all resource viewer
-
+import main.users.views
+import main.api.views
+import main.resources.views  # this should be last because it includes the catch-all resource viewer
 
 # import all models
-from main.users import models
-from main.messages import models
-from main.resources import models
+import main.users.models
+import main.messages.models
+import main.resources.models
+
+
+def _make_use_of_imports():
+    """Reference all the imported things so lint tools won't complain about them being unused."""
+    if app is None or main.resources.models is None:
+        pass

--- a/main/messages/message_sender.py
+++ b/main/messages/message_sender.py
@@ -1,5 +1,4 @@
 import json
-import logging
 import paho.mqtt.client as mqtt
 
 

--- a/main/messages/socket_receiver.py
+++ b/main/messages/socket_receiver.py
@@ -7,15 +7,14 @@ import datetime
 
 # external imports
 import gevent
-from flask.sessions import SecureCookieSessionInterface, total_seconds
-from itsdangerous import BadSignature
 from flask import request
 from flask_login import current_user
 from sqlalchemy import not_
+from sqlalchemy.orm.exc import NoResultFound
 
 
 # internal imports
-from main.app import db, socket_sender, app, message_queue
+from main.app import db, socket_sender, message_queue
 from main.users.auth import find_key
 from main.users.permissions import ACCESS_LEVEL_READ, ACCESS_LEVEL_WRITE
 from main.messages.outgoing_messages import handle_send_email, handle_send_text_message

--- a/main/messages/web_socket_connection.py
+++ b/main/messages/web_socket_connection.py
@@ -1,9 +1,7 @@
-from flask_login import current_user
 from sqlalchemy import not_
 from sqlalchemy.orm.exc import NoResultFound
 from main.app import db
 from main.users.permissions import access_level, ACCESS_LEVEL_NONE
-from main.users.models import User
 from main.resources.models import Resource, ControllerStatus
 
 

--- a/main/resources/file_conversion.py
+++ b/main/resources/file_conversion.py
@@ -79,7 +79,7 @@ def convert_xls_to_csv(data):
     writer = csv.writer(out_stream)
 
     # read rows
-    for i in xrange(ws.nrows):
+    for i in range(ws.nrows):
         row = ws.row_values(i)
         writer.writerow(row)
 

--- a/main/resources/resource_util.py
+++ b/main/resources/resource_util.py
@@ -4,6 +4,7 @@ import time
 import json
 import hashlib
 import datetime
+import logging
 
 
 # external imports

--- a/main/resources/s3_storage_manager.py
+++ b/main/resources/s3_storage_manager.py
@@ -1,5 +1,3 @@
-import io
-
 import boto3
 from botocore.errorfactory import ClientError
 

--- a/main/resources/views.py
+++ b/main/resources/views.py
@@ -8,7 +8,7 @@ from io import StringIO
 
 # external imports
 from flask import render_template, request, abort, Response, send_from_directory, current_app
-from flask_login import login_required, current_user
+from flask_login import current_user
 from jinja2.exceptions import TemplateNotFound
 from sqlalchemy import func, not_
 from sqlalchemy.orm.exc import NoResultFound, MultipleResultsFound
@@ -314,7 +314,6 @@ def file_viewer(resource, check_timing=False, is_home_page=False):
     if contents is None:
         print('file_viewer: storage not found (resource: %d, path: %s)' % (resource.id, resource.path()))
         abort(404)
-    system_attributes = json.loads(resource.system_attributes) if resource.system_attributes else {}
     if resource.name.endswith('.md'):  # fix(soon): revisit this
         if 'edit' in request.args:
             return render_template(

--- a/main/users/auth.py
+++ b/main/users/auth.py
@@ -1,5 +1,4 @@
 # standard python imports
-import os
 import time  # fix(clean): remove
 import random
 import base64
@@ -141,7 +140,7 @@ def find_key(key_text):
 # a temporary/fast version that doesn't actually check for a full key match
 def find_key_fast(key_text):
     key_part = key_text[:3] + key_text[-3:]
-    iph = inner_password_hash(key_text)
+    inner_password_hash(key_text)
     for key in Key.query.filter(Key.key_part == key_part, Key.revocation_timestamp.is_(None)):
         return key
     return None

--- a/main/users/permissions.py
+++ b/main/users/permissions.py
@@ -1,6 +1,5 @@
 import random
 import string
-import json
 from flask import request
 from flask_login import current_user
 from sqlalchemy import not_
@@ -64,7 +63,7 @@ def access_level(permissions, controller_id=None):
         elif type == ACCESS_TYPE_ORG_USERS:
             if user_id:
                 try:
-                    org_user = OrganizationUser.query.filter(OrganizationUser.user_id == user_id, OrganizationUser.organization_id == id).one()
+                    OrganizationUser.query.filter(OrganizationUser.user_id == user_id, OrganizationUser.organization_id == id).one()
                     client_access_level = max(client_access_level, level)
                     break
                 except NoResultFound:

--- a/main/users/views.py
+++ b/main/users/views.py
@@ -5,7 +5,7 @@ from smtplib import SMTPException
 
 
 # external imports
-from flask import render_template, request, flash, redirect, g, abort, Response, current_app
+from flask import render_template, request, redirect, g, abort, Response, current_app
 from sqlalchemy.orm.exc import NoResultFound
 from flask_login import login_required, login_user, logout_user, current_user
 
@@ -157,7 +157,7 @@ def create_account(access_code):
 
         # verify user doesn't already exist with this email address
         try:
-            user = User.query.filter(User.email_address == email_address).one()
+            User.query.filter(User.email_address == email_address).one()
             return Response('An account with that email address already exists.')
         except NoResultFound:
             pass
@@ -165,7 +165,7 @@ def create_account(access_code):
         # verify user doesn't already exist with this user name
         if user_name:
             try:
-                user = User.query.filter(User.user_name == user_name).one()
+                User.query.filter(User.user_name == user_name).one()
                 return Response('User name already in use.')
             except NoResultFound:
                 pass

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,4 @@
-pycodestyle==2.6.0
+flake8==3.8.4
 pytest==6.1.1
 pytest-flask
 pytest-flask-sqlalchemy==1.0.2


### PR DESCRIPTION
Now that pycodestyle is clean, up the ante by using Flake8, which includes
pycodestyle in addition to other checks.

The code changes are mostly unused imports and local variables, but Flake8 found
an actual bug: the wrong user ID was being used in `KeyList.post()`. It also found
a call to `xrange()` which was removed in Python 3.

In a couple of places, the unused variables were used by commented-out debugging
code; I removed the commented-out code since it's trivial to add locally if
needed.

To fix the unused imports in `app_run.py`, I added a dummy function that
references a couple of the symbols. Unclear to me why, but referencing just two of
the imports in code made multiple code checkers (Flake8, pylint, PyCharm) treat
the remaining imports as used.