### PR TITLE
Fix all pylint errors and warnings; add to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -39,6 +39,10 @@ jobs:
       run: |
         .venv/bin/flake8 --max-line-length=150 main tests
 
+    - name: Lint code
+      run: |
+        .venv/bin/pylint main tests
+
     - name: Prep config
       run: |
         .venv/bin/python prep_config.py

--- a/.pylintrc
+++ b/.pylintrc
@@ -1,0 +1,16 @@
+[MESSAGES CONTROL]
+# Only show errors, and suppress E1101 (no-member) because it spews false positives
+# on Flask-SQLAlchemy code due to that library's use of dynamically-created classes.
+disable=C,
+        R,
+        no-member
+
+[MISCELLANEOUS]
+# List of note tags to take in consideration, separated by a comma.
+notes=FIXME,
+      XXX,
+      TODO,
+      fix(soon)
+
+# Regular expression of note tags to take in consideration.
+#notes-rgx=

--- a/README.md
+++ b/README.md
@@ -147,6 +147,7 @@ Coding style guidelines:
 
 *   Maximum line length is 150 characters.
 *   Python code should be PEP8 compliant.
+*   pylint should not produce any warnings or errors (when run with the included `.pylintrc`).
 *   Aim to use single quotes around strings.
 *   Template variables should have spaces just inside brackes: `{{ template_var }}`
 *   Use underscores for database fields, API parameters, message types, and message parameters.

--- a/main/api/messages.py
+++ b/main/api/messages.py
@@ -37,9 +37,9 @@ class MessageList(ApiResource):
         key = find_key(request.authorization.password)
         if not key:
             abort(403)
-        type = request.values['type']
+        message_type = request.values['type']
         parameters = json.loads(request.values['parameters'])
         sender_controller_id = key.access_as_controller_id  # None if access as user
         sender_user_id = key.access_as_user_id  # None if access as controller
-        message_queue.add(folder.id, None, type, parameters, sender_controller_id=sender_controller_id, sender_user_id=sender_user_id)
+        message_queue.add(folder.id, None, message_type, parameters, sender_controller_id=sender_controller_id, sender_user_id=sender_user_id)
         return {'status': 'ok'}

--- a/main/api/users.py
+++ b/main/api/users.py
@@ -15,28 +15,28 @@ from main.users.models import User
 class UserRecord(ApiResource):
 
     # get information about a user
-    def get(self, id):
+    def get(self, user_id):
 
         # a special case for checking whether an account exists
         # fix(soon): carefully throttle this endpoint
         if request.values.get('check_exists', False):
             try:
-                u = User.query.filter(User.email_address == id).one()
+                u = User.query.filter(User.email_address == user_id).one()
                 return {'exists': 1}
             except NoResultFound:
                 try:
-                    u = User.query.filter(User.user_name == id).one()
+                    u = User.query.filter(User.user_name == user_id).one()
                     return {'exists': 1}
                 except NoResultFound:
                     return {'exists': 0}
 
         # normal user lookup
         elif current_user.is_authenticated:
-            if current_user.id == id:
+            if current_user.id == user_id:
                 return current_user.as_dict()
             elif current_user.role == current_user.SYSTEM_ADMIN:
                 try:
-                    u = User.query.filter(User.id == id).one()
+                    u = User.query.filter(User.id == user_id).one()
                 except NoResultFound:
                     abort(404)
                 return u.as_dict()
@@ -44,11 +44,11 @@ class UserRecord(ApiResource):
                 abort(403)
 
     # delete a user
-    def delete(self, id):
+    def delete(self, user_id):
         pass  # requires admin
 
     # update a user
-    def put(self, id):
+    def put(self, user_id):
         pass  # requires admin
 
 

--- a/main/api/views.py
+++ b/main/api/views.py
@@ -100,5 +100,5 @@ def generate_mqtt_info():
 
 
 # add functions that can be used in templates
-app.jinja_env.globals['csrf_token'] = generate_csrf_token
-app.jinja_env.globals['mqtt_info'] = generate_mqtt_info
+app.add_template_global(name='csrf_token', f=generate_csrf_token)
+app.add_template_global(name='mqtt_info', f=generate_mqtt_info)

--- a/main/app.py
+++ b/main/app.py
@@ -64,12 +64,12 @@ else:
 
 
 @app.errorhandler(403)
-def forbidden(error):
+def forbidden(error):  # pylint: disable=unused-argument
     return render_template('403.html'), 403
 
 
 @app.errorhandler(404)
-def not_found(error):
+def not_found(error):  # pylint: disable=unused-argument
     return render_template('404.html'), 404
 
 # require SSL for all pages; based on code from http://stackoverflow.com/questions/32237379/python-flask-redirect-to-https-from-http
@@ -133,5 +133,5 @@ def file_hash(local_file_name):
 
 
 # add static file function for templates
-app.jinja_env.globals['static_file'] = static_file
-app.jinja_env.globals['ext_static_file'] = ext_static_file
+app.add_template_global(name='static_file', f=static_file)
+app.add_template_global(name='ext_static_file', f=ext_static_file)

--- a/main/config.py
+++ b/main/config.py
@@ -63,7 +63,7 @@ def environment():
 
     settings = {}
 
-    for setting, default in defaults().items():
+    for setting in defaults().keys():
         from_environ = os.environ.get('RHIZO_SERVER_' + setting, os.environ.get(setting, None))
         if from_environ:
             settings[setting] = yaml.load(from_environ, yaml.Loader)

--- a/main/messages/message_queue.py
+++ b/main/messages/message_queue.py
@@ -2,7 +2,7 @@
 class MessageQueue(object):
 
     # add a single message to the queue
-    def add(self, folder_id, folder_path, type, parameters=None, sender_controller_id=None, sender_user_id=None, timestamp=None):
+    def add(self, folder_id, folder_path, message_type, parameters=None, sender_controller_id=None, sender_user_id=None, timestamp=None):
         pass
 
     # returns a list of message objects once some are ready

--- a/main/messages/message_queue_basic.py
+++ b/main/messages/message_queue_basic.py
@@ -12,7 +12,7 @@ class MessageQueueBasic(MessageQueue):
         self._start_timestamp = datetime.datetime.utcnow()
 
     # add a single message to the queue
-    def add(self, folder_id, folder_path, type, parameters=None, sender_controller_id=None, sender_user_id=None, timestamp=None):
+    def add(self, folder_id, folder_path, message_type, parameters=None, sender_controller_id=None, sender_user_id=None, timestamp=None):
         # fix(soon): add warning if type is too long
         from main.messages.models import Message  # would like to do at top, but creates import loop in __init__
         from main.app import db  # would like to do at top, but creates import loop in __init__
@@ -24,14 +24,14 @@ class MessageQueueBasic(MessageQueue):
         message_record.sender_controller_id = sender_controller_id
         message_record.sender_user_id = sender_user_id
         message_record.folder_id = folder_id
-        message_record.type = type
+        message_record.type = message_type
         message_record.parameters = json.dumps(parameters) if parameters else '{}'
         db.session.add(message_record)
         db.session.commit()
         if folder_path:
             from main.app import message_sender
             if message_sender:
-                message_sender.send_message(folder_path, type, parameters, timestamp)
+                message_sender.send_message(folder_path, message_type, parameters, timestamp)
 
     # returns a list of message objects once some are ready
     def receive(self):

--- a/main/messages/message_sender.py
+++ b/main/messages/message_sender.py
@@ -15,6 +15,7 @@ class MessageSender(object):
         from main.users.auth import message_auth_token
 
         def on_connect(client, userdata, flags, rc):
+            # pylint: disable=unused-argument
             if rc:
                 print('unable to connect to MQTT broker/server at %s:%d' % (self.mqtt_host, self.mqtt_port))
             else:
@@ -26,11 +27,11 @@ class MessageSender(object):
         self.mqtt_client.connect(self.mqtt_host, self.mqtt_port)
         self.mqtt_client.loop_start()
 
-    def send_message(self, path, type, parameters, timestamp=None):
+    def send_message(self, path, message_type, parameters, timestamp=None):
         if not self.mqtt_client:
             self.connect()
         message_struct = {
-            'type': type,
+            'type': message_type,
             'parameters': parameters
         }
         if timestamp:

--- a/main/messages/models.py
+++ b/main/messages/models.py
@@ -15,7 +15,7 @@ class Message(db.Model):
     attributes = db.Column(db.String, comment='JSON field containing extra message attributes')
 
     def __repr__(self):
-        return '%d: %s, %s' % (self.id, self.timestamp, self.type)
+        return '%d: %s, %s' % (int(self.id), self.timestamp, self.type)
 
 
 # The ActionThrottle model is used to rate-limit certain client-requested activities like sending emails/texts.

--- a/main/messages/outgoing_messages.py
+++ b/main/messages/outgoing_messages.py
@@ -83,7 +83,7 @@ def handle_send_text_message(controller_id, parameters):
 
 
 # check the rate limiting on an action such as sending an email or text
-def check_and_update_throttle(controller_id, type):
+def check_and_update_throttle(controller_id, action_type):
 
     # get timestamp
     dt = datetime.datetime.utcnow()
@@ -92,7 +92,7 @@ def check_and_update_throttle(controller_id, type):
 
     # if existing record, check recent usage
     try:
-        action_throttle = ActionThrottle.query.filter(ActionThrottle.controller_id == controller_id, ActionThrottle.type == type).one()
+        action_throttle = ActionThrottle.query.filter(ActionThrottle.controller_id == controller_id, ActionThrottle.type == action_type).one()
         recent_usage = [int(ts) for ts in action_throttle.recent_usage.split(',')]
         recent_usage = [ts for ts in recent_usage if ts > threshold]
         recent_usage.append(timestamp)
@@ -105,7 +105,7 @@ def check_and_update_throttle(controller_id, type):
     except NoResultFound:
         action_throttle = ActionThrottle()
         action_throttle.controller_id = controller_id
-        action_throttle.type = type
+        action_throttle.type = action_type
         action_throttle.recent_usage = str(timestamp)
         db.session.add(action_throttle)
         db.session.commit()

--- a/main/messages/socket_sender.py
+++ b/main/messages/socket_sender.py
@@ -43,12 +43,12 @@ class SocketSender(object):
 
     # register a client (possible message recipient)
     def register(self, ws_conn):
-        logging.info('client registered (%s)' % ws_conn)
+        logging.info('client registered (%s)', ws_conn)
         self.connections.append(ws_conn)
 
     # unregister a client (e.g. after it has been closed
     def unregister(self, ws_conn):
-        logging.info('client unregistered (%s)' % ws_conn)
+        logging.info('client unregistered (%s)', ws_conn)
         self.connections.remove(ws_conn)
 
     # send a message to a specific client (using websocket connection specified in ws_conn)
@@ -58,12 +58,12 @@ class SocketSender(object):
             try:
                 ws_conn.ws.send(message)
             except WebSocketError:
-                print('unable to send to websocket (%s)' % ws_conn)
+                print('unable to send to websocket (%s)', ws_conn)
 
     # send a message structure to a specific client
-    def send_message(self, ws_conn, type, parameters):
+    def send_message(self, ws_conn, message_type, parameters):
         message_struct = {
-            'type': type,
+            'type': message_type,
             'timestamp': datetime.datetime.utcnow().isoformat() + 'Z',
             'parameters': parameters
         }
@@ -81,10 +81,10 @@ class SocketSender(object):
             # get all messages since the last message we processed
             messages = message_queue.receive()
             if self._debug_messaging:
-                logging.debug('received %d messages from message queue' % messages.count())
+                logging.debug('received %d messages from message queue', messages.count())
             for message in messages:
                 if self._debug_messaging:
-                    logging.debug('message type: %s, folder: %s' % (message.type, message.folder_id))
+                    logging.debug('message type: %s, folder: %s', message.type, message.folder_id)
 
                 # handle special messages aimed at this module
                 if message.type == 'requestProcessStatus':
@@ -102,9 +102,9 @@ class SocketSender(object):
                             gevent.spawn(self.send, ws_conn, json.dumps(message_struct))
                             if self._debug_messaging:
                                 if ws_conn.controller_id:
-                                    logging.debug('sending message to controller; type: %s' % message.type)
+                                    logging.debug('sending message to controller; type: %s', message.type)
                                 else:
-                                    logging.debug('sending message to browser; type: %s' % message.type)
+                                    logging.debug('sending message to browser; type: %s', message.type)
 
     # spawn a greenlet that sends messages to clients
     def start(self):

--- a/main/resources/models.py
+++ b/main/resources/models.py
@@ -119,11 +119,11 @@ class Resource(db.Model):
 
             # if we have permissions at this level, we need to merge in the parent permissions
             if self.permissions:
-                permission_dict = {(type, id): level for (type, id, level) in self.permissions}
+                permission_dict = {(permission_type, principal_id): level for (permission_type, principal_id, level) in self.permissions}
                 for permission_record in parent_permissions:
-                    (type, id, level) = permission_record
-                    if not (type, id) in permission_dict:
-                        permissions.append((type, id, level))
+                    (permission_type, principal_id, level) = permission_record
+                    if not (permission_type, principal_id) in permission_dict:
+                        permissions.append((permission_type, principal_id, level))
 
             # otherwise, just use the parent permissions (the common case)
             else:
@@ -135,8 +135,8 @@ class Resource(db.Model):
         org_id = self.organization_id
         if not org_id:  # fix(clean): remove this
             org_id = self.root().id
-        id_str = '%09d' % self.id
-        return '%d/%s/%s/%s/%d_%d' % (org_id, id_str[-9:-6], id_str[-6:-3], id_str[-3:], self.id, revision_id)
+        id_str = '%09d' % int(self.id)
+        return '%d/%s/%s/%s/%d_%d' % (org_id, id_str[-9:-6], id_str[-6:-3], id_str[-3:], int(self.id), revision_id)
 
 
 # The ResourceRevision model holds a revision history or time series history of a resource.

--- a/main/resources/resource_util.py
+++ b/main/resources/resource_util.py
@@ -160,16 +160,16 @@ def split_camel_case(name):
 # determine (guess) the mimetype of a file based on its file name extension
 def mime_type_from_ext(file_name):
     file_ext = file_name.rsplit('.', 1)[-1]
-    type = ''
+    mime_type = ''
     if file_ext == 'jpg':
-        type = 'image/jpeg'
+        mime_type = 'image/jpeg'
     elif file_ext == 'png':
-        type = 'image/png'
+        mime_type = 'image/png'
     elif file_ext == 'txt':
-        type = 'text/plain'
+        mime_type = 'text/plain'
     elif file_ext == 'csv':
-        type = 'text/csv'
-    return type
+        mime_type = 'text/csv'
+    return mime_type
 
 
 # this is a high-level function for setting the value of a sequence;
@@ -207,7 +207,7 @@ def update_sequence_value(resource, resource_path, timestamp, value, emit_messag
         if data_type == Resource.IMAGE_SEQUENCE:
             max_width = 240
             name = 'thumbnail-%d-x' % max_width
-            (thumbnail_contents, thumbnail_width, thumbnail_height) = compute_thumbnail(value, max_width)
+            thumbnail_contents = compute_thumbnail(value, max_width)[0]
             try:
                 thumbnail_resource = Resource.query.filter(Resource.parent_id == resource.id, Resource.name == name, not_(Resource.deleted)).one()
             except NoResultFound:
@@ -221,7 +221,7 @@ def update_sequence_value(resource, resource_path, timestamp, value, emit_messag
     if emit_message:
         folder_path = resource_path.rsplit('/', 1)[0]
         message_queue.add(
-            folder_id=resource.parent_id, folder_path=folder_path, type='sequence_update', parameters=message_params, timestamp=timestamp)
+            folder_id=resource.parent_id, folder_path=folder_path, message_type='sequence_update', parameters=message_params, timestamp=timestamp)
 
 
 # creates a resource revision record; places the data in the record (if it is small) or bulk storage (if it is large);

--- a/main/resources/views.py
+++ b/main/resources/views.py
@@ -141,7 +141,7 @@ def view_item(item_path):
 
             # use a built-in resource viewer based on resource type
             if resource.type == Resource.APP and resource.path().startswith('/system/'):
-                return system_app_viewer(resource, parent_folder)
+                return system_app_viewer(resource)
             elif resource.type == Resource.SEQUENCE:
                 return sequence_viewer(resource)
             elif resource.type == Resource.FILE:
@@ -244,7 +244,7 @@ def folder_tree_viewer(folder):
 
 
 # view a system app
-def system_app_viewer(resource, parent):
+def system_app_viewer(resource):
     template_name = 'system/%s.html' % resource.name.replace(' ', '_').lower()
     try:
         return render_template(template_name)

--- a/main/users/models.py
+++ b/main/users/models.py
@@ -17,7 +17,7 @@ class User(UserMixin, db.Model):
     role = db.Column(db.Integer, nullable=False)
 
     def __repr__(self):
-        return '%d: %s' % (self.id, self.email_address)
+        return '%d: %s' % (int(self.id), self.email_address)
 
     def as_dict(self):
         return {

--- a/main/users/permissions.py
+++ b/main/users/permissions.py
@@ -53,43 +53,43 @@ def access_level(permissions, controller_id=None):
 
     # take max level of all applicable permissions
     for permission_record in permissions:
-        (type, id, level) = permission_record
+        (permission_type, principal_id, level) = permission_record
 
         # applies to everyone
-        if type == ACCESS_TYPE_PUBLIC:
+        if permission_type == ACCESS_TYPE_PUBLIC:
             client_access_level = max(client_access_level, level)
 
         # applies if current user is contained within the organization given by the permission ID
-        elif type == ACCESS_TYPE_ORG_USERS:
+        elif permission_type == ACCESS_TYPE_ORG_USERS:
             if user_id:
                 try:
-                    OrganizationUser.query.filter(OrganizationUser.user_id == user_id, OrganizationUser.organization_id == id).one()
+                    OrganizationUser.query.filter(OrganizationUser.user_id == user_id, OrganizationUser.organization_id == principal_id).one()
                     client_access_level = max(client_access_level, level)
                     break
                 except NoResultFound:
                     pass
 
         # applies if current controller is contained within the organization given by the permission ID
-        elif type == ACCESS_TYPE_ORG_CONTROLLERS:
+        elif permission_type == ACCESS_TYPE_ORG_CONTROLLERS:
             if controller_id:
                 try:
                     controller = Resource.query.filter(Resource.id == controller_id, not_(Resource.deleted)).one()
                     # fix(soon): remove this after all resources have org ids
                     controller_org_id = controller.organization_id if controller.organization_id else controller.root().id
-                    if controller_org_id == id:
+                    if controller_org_id == principal_id:
                         client_access_level = max(client_access_level, level)
                     break
                 except NoResultFound:
                     pass
 
         # applies if permission ID is the same as current user ID
-        elif type == ACCESS_TYPE_USER:
-            if user_id and user_id == id:
+        elif permission_type == ACCESS_TYPE_USER:
+            if user_id and user_id == principal_id:
                 client_access_level = max(client_access_level, level)
 
         # applies if permission ID is the same as current controller ID
-        elif type == ACCESS_TYPE_CONTROLLER:
-            if controller_id and controller_id == id:
+        elif permission_type == ACCESS_TYPE_CONTROLLER:
+            if controller_id and controller_id == principal_id:
                 client_access_level = max(client_access_level, level)
 
     return client_access_level

--- a/main/util.py
+++ b/main/util.py
@@ -23,16 +23,16 @@ def ssl_required(fn):
 # note: this function is also defined in client code
 def parse_json_datetime(json_timestamp):
     assert json_timestamp.endswith('Z')
-    format = ''
+    format_str = ''
     if '.' in json_timestamp:
-        format = '%Y-%m-%dT%H:%M:%S.%f'
+        format_str = '%Y-%m-%dT%H:%M:%S.%f'
     else:
-        format = '%Y-%m-%dT%H:%M:%S'
+        format_str = '%Y-%m-%dT%H:%M:%S'
     if json_timestamp.endswith(' Z'):
-        format += ' Z'
+        format_str += ' Z'
     else:
-        format += 'Z'
-    return datetime.datetime.strptime(json_timestamp, format)
+        format_str += 'Z'
+    return datetime.datetime.strptime(json_timestamp, format_str)
 
 
 # get the current server configuration module (for use when current_app isn't available)

--- a/main/workers/controller_watchdog.py
+++ b/main/workers/controller_watchdog.py
@@ -70,6 +70,7 @@ def controller_watchdog():
 
         # handle all exceptions because we don't want an error in this code (e.g. sending email or bad status/controller data) stopping all
         # notifications
+        # pylint: disable=broad-except
         except Exception as e:
             print('controller_watchdog error: %s' % str(e))
             worker_log('controller_watchdog', str(e))

--- a/main/workers/message_monitor.py
+++ b/main/workers/message_monitor.py
@@ -31,6 +31,7 @@ def message_monitor():
 
     # run this on connect/reconnect
     def on_connect(client, userdata, flags, rc):
+        # pylint: disable=unused-argument
         if rc:
             worker_log('message_monitor', 'unable to connect to MQTT broker/server at %s:%d' % (mqtt_host, mqtt_port))
         else:
@@ -39,6 +40,7 @@ def message_monitor():
 
     # run this on message
     def on_message(client, userdata, msg):
+        # pylint: disable=unused-argument
         # print('MQTT: %s %s' % (msg.topic, msg.payload.decode()))
         message_struct = json.loads(msg.payload.decode())
         message_type = message_struct['type']

--- a/tests/README.md
+++ b/tests/README.md
@@ -34,6 +34,8 @@ The tests make heavy use of [pytest fixtures](https://docs.pytest.org/en/stable/
 
 For example, if a test needs a `Key` resource, it implicitly needs a `User` to own the key, and the `User` implicitly needs an `Organization` to belong to. The test function just needs to declare the `Key` as a parameter and the other tables will be initialized as well.
 
+If the test method is only declaring a fixture dependency for its side effects and is never actually using the fixture object, it should use a `@pytest.mark.usefixtures` decorator instead of a parameter.
+
 As a pleasant side effect, this reduces the amount of module importing that needs to happen in test functions, since they can just ask for the model objects (by declaring the fixtures as parameters).
 
 ### Classes
@@ -41,6 +43,8 @@ As a pleasant side effect, this reduces the amount of module importing that need
 The test suite uses a mix of top-level functions and classes.
 
 Classes are used in part to reduce repetitive fixture declaration. That is, if you have 10 semantically-related test functions that all need the same set of fixtures, it's cleaner to put them in a class that has a setup method that takes the fixtures as arguments and stores them in `self`.
+
+If the class only needs a fixture for its side effects and will never use the fixture object, add a `@pytest.mark.usefixtures` decorator to the class and list the fixture there.
 
 If you do that, just decorate the setup function with `@pytest.fixture(autouse=True)` and pytest will call it automatically.
 

--- a/tests/requirements.txt
+++ b/tests/requirements.txt
@@ -1,4 +1,5 @@
 flake8==3.8.4
+pylint==2.6.0
 pytest==6.1.1
 pytest-flask
 pytest-flask-sqlalchemy==1.0.2

--- a/tests/test_controller_status.py
+++ b/tests/test_controller_status.py
@@ -1,6 +1,8 @@
 import datetime
 import json
 
+import pytest
+
 from main.resources.models import ControllerStatus
 from main.messages.socket_receiver import process_web_socket_message
 from main.messages.web_socket_connection import WebSocketConnection
@@ -19,7 +21,8 @@ def test_controller_watchdog(db_session, controller_resource):
     assert delta.total_seconds() < 60
 
 
-def test_controller_status(db_session, controller_resource, client, app, api):
+@pytest.mark.usefixtures('app', 'api')
+def test_controller_status(db_session, controller_resource, client):
     assert client.put("/api/v1/resources/folder/controller",
                       content_type="application/x-www-form-urlencoded",
                       data={"status": """{"foo":"bar"}"""}).status_code == 200

--- a/tests/test_resource_api.py
+++ b/tests/test_resource_api.py
@@ -9,12 +9,16 @@ import pytest
 from main.resources.models import Resource
 
 
+@pytest.mark.usefixtures('api', 'folder_resource')
 class TestResourceOperations:
     @pytest.fixture(autouse=True)
-    def setup(self, client, api, folder_resource):
+    def setup(self, client):
+        # pylint: disable=attribute-defined-outside-init
         self.client = client
 
     def _write_then_read(self, content: Union[bytes, str]):
+        # https://github.com/PyCQA/pylint/issues/3882
+        # pylint: disable=unsubscriptable-object
         """Write a file and then read it again to make sure the content matches."""
         url_prefix = '/api/v1/resources'
         folder = '/folder'
@@ -132,7 +136,9 @@ class TestResourceOperations:
 
 class TestSendMessage:
     @pytest.fixture(autouse=True)
-    def setup(self, client, folder_resource, user_resource, controller_key_resource):
+    @pytest.mark.usefixtures('folder_resource')
+    def setup(self, client, user_resource, controller_key_resource):
+        # pylint: disable=attribute-defined-outside-init
         auth = base64.b64encode(
             f'{user_resource.user_name}:{controller_key_resource.text}'.encode()).decode()
         self.headers = {'Authorization': f'Basic {auth}'}


### PR DESCRIPTION
Introduce pylint to do deeper analysis of the code than flake8 supports.
Currently, only errors and warnings are enabled (not suggested refactoring and
convention violations), and this change fixes the code so that pylint passes.

The fixes fall into a few categories:

* Renaming variables to avoid conflicts with built-in function names. This was by
  far the biggest category of warnings. This doesn't affect class field names so
  should have no impact on SQLAlchemy. The frequent offenders were `id`, `type`,
  `filter`, and `zip`.
* Logging calls that formatted messages with the `%` operator; these now pass the
  format arguments to the logging functions.
* Implicit int conversion of SQLAlchemy numeric column objects. These work but
  pylint doesn't know about them, so they now have explicit `int()` wrappers.

Thanks to limitations/bugs in pylint, there were some errors that weren't possible
to clean up by changing the code, so they're disabled here:

* `no-member` is the big one: pylint complains about all the dynamically-created
  functions on SQLAlchemy objects (e.g., the `filter` method on queries) and the
  config option that's supposed to let you manually tell it which names get added
  to which classes is broken right now: https://github.com/PyCQA/pylint/issues/2498
* Unused argument checking is disabled for functions that are passed as callbacks
  to libraries.
* In the test code, we need to set environment variables before importing Flask
  modules with side effects, so the "all imports have to be at the top of the
  module" check is disabled there.
* pytest doesn't let you define test classes with initializer functions, so the
  "attribute defined outside initializer" check is disabled there.