### PR TITLE
Install libpq in Docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,10 @@ FROM python:3.8.5-buster
 
 WORKDIR /rhizo-server
 
+RUN apt-get update \
+    && apt-get install -y libpq5 \
+    && rm -rf /var/cache/apt/lists
+
 COPY --from=build /usr/local/lib/python3.8/site-packages /usr/local/lib/python3.8/site-packages
 
 # copy in the app source


### PR DESCRIPTION
Without this, the server can't talk to a Postgres database server since
psycopg2-binary depends on it.
